### PR TITLE
add tests for script enforcement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@ WFLAGS=-Werror -Wextra -Wpedantic
 SRC=src
 VOL=vol
 VOL_FSVERITY=vol_fsverity
+
+# Kernel headers for AT_EXECVE_CHECK support (requires Linux 6.14+)
+KERNEL_DIR ?= /usr/src/linux-headers-$(shell uname -r)
+KERNEL_INCLUDES = -I$(KERNEL_DIR)/include/uapi -I$(KERNEL_DIR)/include
 OUTPUT=output
 PYTHON=python3
 POLICY=policies
 
-all: hello hellosh hellolib memfd_test mmap_test mprotect_test copy_lib copy_bin $(VOL) $(VOL_FSVERITY)
+all: hello hellosh hellolib memfd_test mmap_test mprotect_test copy_lib copy_bin inc incrementinc $(VOL) $(VOL_FSVERITY)
 
 $(VOL):
 	mkdir -p $(VOL)
@@ -56,6 +60,14 @@ $(VOL)/bin/mmap_test: $(VOL)
 mprotect_test: $(VOL)/bin/mprotect_test
 $(VOL)/bin/mprotect_test: $(VOL)
 	$(CC) $(WFLAGS) -o $(VOL)/bin/mprotect_test $(SRC)/mprotect_test.c
+
+inc: $(VOL)/bin/inc
+$(VOL)/bin/inc: $(VOL) $(SRC)/inc.c
+	$(CC) -Wall -Wextra $(KERNEL_INCLUDES) -o $(VOL)/bin/inc $(SRC)/inc.c
+
+incrementinc: $(VOL)/script/increment.inc
+$(VOL)/script/increment.inc: $(VOL) $(SRC)/increment.inc
+	cp -p $(SRC)/increment.inc $(VOL)/script/increment.inc
 
 prepare_test:
 	mkdir -p $(OUTPUT)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OUTPUT=output
 PYTHON=python3
 POLICY=policies
 
-all: hello hellosh hellolib memfd_test mmap_test mprotect_test copy_lib copy_bin inc incrementinc $(VOL) $(VOL_FSVERITY)
+all: hello hellosh hellolib memfd_test mmap_test mprotect_test inc incrementinc copy_lib copy_bin $(VOL) $(VOL_FSVERITY)
 
 $(VOL):
 	mkdir -p $(VOL)

--- a/README.md
+++ b/README.md
@@ -20,12 +20,32 @@ The following dependencies are required:
 - fsverity
 - gcc
 - keyutils
+- Linux kernel 6.14+ (Required for AT_EXECVE_CHECK support in script interpretation)
 
 You can install all dependencies using the following command:
 
 ```bash
 apt install build-essential patchelf fsverity keyutils
 ```
+
+### Kernel Headers
+
+For AT_EXECVE_CHECK functionality, you need Linux 6.14+ kernel headers for compilation.
+
+**Default header locations** (the build system checks these automatically):
+- `/usr/src/linux-headers-$(uname -r)/include/uapi/`
+- `/usr/src/linux-headers-$(uname -r)/include/`
+
+**Using custom header location:**
+If you have kernel source/headers in a different location:
+```bash
+make KERNEL_DIR=/path/to/kernel/source
+# Example: make KERNEL_DIR=/home/user/linux-6.16.5
+```
+
+The build system will look for headers in:
+- `$(KERNEL_DIR)/include/uapi/linux/fcntl.h` (for AT_EXECVE_CHECK definition)
+- `$(KERNEL_DIR)/include/linux/` (for other kernel headers)
 
 ## Preparing for Testing
 

--- a/src/inc.c
+++ b/src/inc.c
@@ -5,6 +5,9 @@
  * - "?" to initialize a counter from user's input;
  * - "+" to increment the counter (which is set to 0 by default).
  *
+ * This file is adapted from:
+ * samples/check-exec/inc.c from the Linux kernel source tree
+ *
  * See tools/testing/selftests/exec/check-exec-tests.sh and
  * Documentation/userspace-api/check_exec.rst
  *

--- a/src/inc.c
+++ b/src/inc.c
@@ -104,8 +104,10 @@ static void print_usage(const char *argv0)
 {
 	fprintf(stderr, "usage: %s <script.inc> | -i | -c <command>\n\n",
 		argv0);
-	fprintf(stderr, "Example:\n");
-	fprintf(stderr, "  ./set-exec -fi -- ./inc -i < script-exec.inc\n");
+	fprintf(stderr, "Examples:\n");
+	fprintf(stderr, "  %s script.inc\n", argv0);
+	fprintf(stderr, "  %s -i < script.inc\n", argv0);
+	fprintf(stderr, "  %s -c '+'\n", argv0);
 }
 
 int main(const int argc, char *const argv[], char *const *const envp)
@@ -146,9 +148,17 @@ int main(const int argc, char *const argv[], char *const *const envp)
 
 	if (cmd) {
 		/*
-		 * For IPE testing, we don't need securebits-based interactive
-		 * denial. Just process the command directly.
+		 * For IPE testing with command-line execution, we also
+		 * enforce via AT_EXECVE_CHECK to ensure consistent policy
+		 * enforcement across all execution modes.
 		 */
+		char *const cmd_argv[] = { argv[0], "-c", cmd, NULL };
+		int err = sys_execveat(AT_FDCWD, argv[0], cmd_argv, envp, AT_EXECVE_CHECK);
+		if (err) {
+			fprintf(stderr,
+				"Command execution denied by security policy (errno=%d)\n", errno);
+			return errno;
+		}
 		return interpret_buffer(cmd, strlen(cmd));
 	}
 

--- a/src/inc.c
+++ b/src/inc.c
@@ -73,7 +73,7 @@ static int interpret_buffer(char *buffer, size_t buffer_size)
 	return 0;
 }
 
-/* Returns 1 on error, 0 otherwise. */
+/* Returns errno on error, 0 otherwise. */
 static int interpret_stream(FILE *script, char *const script_name,
 			    char *const *const envp)
 {
@@ -102,67 +102,37 @@ static int interpret_stream(FILE *script, char *const script_name,
 
 static void print_usage(const char *argv0)
 {
-	fprintf(stderr, "usage: %s <script.inc> | -i | -c <command>\n\n",
+	fprintf(stderr, "usage: %s <script.inc> | -i\n\n",
 		argv0);
 	fprintf(stderr, "Examples:\n");
 	fprintf(stderr, "  %s script.inc\n", argv0);
 	fprintf(stderr, "  %s -i < script.inc\n", argv0);
-	fprintf(stderr, "  %s -c '+'\n", argv0);
 }
 
 int main(const int argc, char *const argv[], char *const *const envp)
 {
 	int opt;
-	char *cmd = NULL;
 	char *script_name = NULL;
 	bool interpret_stdin = false;
 	FILE *script_file = NULL;
-	size_t arg_nb;
 
-	while ((opt = getopt(argc, argv, "c:i")) != -1) {
-		switch (opt) {
-		case 'c':
-			if (cmd) {
-				fprintf(stderr, "ERROR: Command already set");
-				return 1;
-			}
-			cmd = optarg;
-			break;
-		case 'i':
+	while ((opt = getopt(argc, argv, "i")) != -1) {
+		if (opt == 'i') {
 			interpret_stdin = true;
-			break;
-		default:
+		} else {
 			print_usage(argv[0]);
 			return 1;
 		}
 	}
 
-	/* Checks that only one argument is used, or read stdin. */
-	arg_nb = !!cmd + !!interpret_stdin;
-	if (arg_nb == 0 && argc == 2) {
+	if (!interpret_stdin && argc == 2) {
 		script_name = argv[1];
-	} else if (arg_nb != 1) {
+	} else if (!interpret_stdin && argc != 2) {
 		print_usage(argv[0]);
 		return 1;
 	}
 
-	if (cmd) {
-		/*
-		 * For IPE testing with command-line execution, we also
-		 * enforce via AT_EXECVE_CHECK to ensure consistent policy
-		 * enforcement across all execution modes.
-		 */
-		char *const cmd_argv[] = { argv[0], "-c", cmd, NULL };
-		int err = sys_execveat(AT_FDCWD, argv[0], cmd_argv, envp, AT_EXECVE_CHECK);
-		if (err) {
-			fprintf(stderr,
-				"Command execution denied by security policy (errno=%d)\n", errno);
-			return errno;
-		}
-		return interpret_buffer(cmd, strlen(cmd));
-	}
-
-	if (interpret_stdin && !script_name) {
+	if (interpret_stdin) {
 		script_file = stdin;
 		/*
 		 * As for any execve(2) call, this path may be logged by the
@@ -173,7 +143,7 @@ int main(const int argc, char *const argv[], char *const *const envp)
 		 * For IPE testing with stdin, always enforce via AT_EXECVE_CHECK.
 		 */
 		return interpret_stream(script_file, script_name, envp);
-	} else if (script_name && !interpret_stdin) {
+	} else if (script_name) {
 		/*
 		 * In this sample, we don't pass any argument to scripts, but
 		 * otherwise we would have to forge an argv with such

--- a/src/inc.c
+++ b/src/inc.c
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Very simple script interpreter that can evaluate two different commands (one
+ * per line):
+ * - "?" to initialize a counter from user's input;
+ * - "+" to increment the counter (which is set to 0 by default).
+ *
+ * See tools/testing/selftests/exec/check-exec-tests.sh and
+ * Documentation/userspace-api/check_exec.rst
+ *
+ * Copyright © 2024 Microsoft Corporation
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <linux/fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+
+static int sys_execveat(int dirfd, const char *pathname, char *const argv[],
+			char *const envp[], int flags)
+{
+	return syscall(__NR_execveat, dirfd, pathname, argv, envp, flags);
+}
+
+/* Returns 1 on error, 0 otherwise. */
+static int interpret_buffer(char *buffer, size_t buffer_size)
+{
+	char *line, *saveptr = NULL;
+	long long number = 0;
+
+	/* Each command is the first character of a line. */
+	saveptr = NULL;
+	line = strtok_r(buffer, "\n", &saveptr);
+	while (line) {
+		if (*line != '#' && strlen(line) != 1) {
+			fprintf(stderr, "# ERROR: Unknown string\n");
+			return 1;
+		}
+		switch (*line) {
+		case '#':
+			/* Skips shebang and comments. */
+			break;
+		case '+':
+			/* Increments and prints the number. */
+			number++;
+			printf("%lld\n", number);
+			break;
+		case '?':
+			/* Reads integer from stdin. */
+			fprintf(stderr, "> Enter new number: \n");
+			if (scanf("%lld", &number) != 1) {
+				fprintf(stderr,
+					"# WARNING: Failed to read number from stdin\n");
+			}
+			break;
+		default:
+			fprintf(stderr, "# ERROR: Unknown character '%c'\n",
+				*line);
+			return 1;
+		}
+		line = strtok_r(NULL, "\n", &saveptr);
+	}
+	return 0;
+}
+
+/* Returns 1 on error, 0 otherwise. */
+static int interpret_stream(FILE *script, char *const script_name,
+			    char *const *const envp)
+{
+	int err;
+	char *const script_argv[] = { script_name, NULL };
+	char buf[128] = {};
+	size_t buf_size = sizeof(buf);
+
+	/*
+	 * Consult IPE via AT_EXECVE_CHECK before executing the script.
+	 * We use path-based execveat() to allow the kernel to properly
+	 * evaluate the script's integrity properties.
+	 */
+	err = sys_execveat(fileno(script), "", script_argv, envp,
+			   AT_EMPTY_PATH | AT_EXECVE_CHECK);
+	if (err) {
+		fprintf(stderr,
+			"Script execution denied by security policy (errno=%d)\n", errno);
+		return errno;
+	}
+
+	/* Reads script. */
+	buf_size = fread(buf, 1, buf_size - 1, script);
+	return interpret_buffer(buf, buf_size);
+}
+
+static void print_usage(const char *argv0)
+{
+	fprintf(stderr, "usage: %s <script.inc> | -i | -c <command>\n\n",
+		argv0);
+	fprintf(stderr, "Example:\n");
+	fprintf(stderr, "  ./set-exec -fi -- ./inc -i < script-exec.inc\n");
+}
+
+int main(const int argc, char *const argv[], char *const *const envp)
+{
+	int opt;
+	char *cmd = NULL;
+	char *script_name = NULL;
+	bool interpret_stdin = false;
+	FILE *script_file = NULL;
+	size_t arg_nb;
+
+	while ((opt = getopt(argc, argv, "c:i")) != -1) {
+		switch (opt) {
+		case 'c':
+			if (cmd) {
+				fprintf(stderr, "ERROR: Command already set");
+				return 1;
+			}
+			cmd = optarg;
+			break;
+		case 'i':
+			interpret_stdin = true;
+			break;
+		default:
+			print_usage(argv[0]);
+			return 1;
+		}
+	}
+
+	/* Checks that only one argument is used, or read stdin. */
+	arg_nb = !!cmd + !!interpret_stdin;
+	if (arg_nb == 0 && argc == 2) {
+		script_name = argv[1];
+	} else if (arg_nb != 1) {
+		print_usage(argv[0]);
+		return 1;
+	}
+
+	if (cmd) {
+		/*
+		 * For IPE testing, we don't need securebits-based interactive
+		 * denial. Just process the command directly.
+		 */
+		return interpret_buffer(cmd, strlen(cmd));
+	}
+
+	if (interpret_stdin && !script_name) {
+		script_file = stdin;
+		/*
+		 * As for any execve(2) call, this path may be logged by the
+		 * kernel.
+		 */
+		script_name = "/proc/self/fd/0";
+		/*
+		 * For IPE testing with stdin, always enforce via AT_EXECVE_CHECK.
+		 */
+		return interpret_stream(script_file, script_name, envp);
+	} else if (script_name && !interpret_stdin) {
+		/*
+		 * In this sample, we don't pass any argument to scripts, but
+		 * otherwise we would have to forge an argv with such
+		 * arguments.
+		 */
+		script_file = fopen(script_name, "r");
+		if (!script_file) {
+			perror("ERROR: Failed to open script");
+			return 1;
+		}
+		/*
+		 * For IPE testing with script files, always enforce via AT_EXECVE_CHECK.
+		 */
+		return interpret_stream(script_file, script_name, envp);
+	}
+
+	print_usage(argv[0]);
+	return 1;
+}

--- a/src/inc.c
+++ b/src/inc.c
@@ -33,7 +33,7 @@ static int sys_execveat(int dirfd, const char *pathname, char *const argv[],
 }
 
 /* Returns 1 on error, 0 otherwise. */
-static int interpret_buffer(char *buffer, size_t buffer_size)
+static int interpret_buffer(char *buffer)
 {
 	char *line, *saveptr = NULL;
 	long long number = 0;
@@ -97,7 +97,7 @@ static int interpret_stream(FILE *script, char *const script_name,
 
 	/* Reads script. */
 	buf_size = fread(buf, 1, buf_size - 1, script);
-	return interpret_buffer(buf, buf_size);
+	return interpret_buffer(buf);
 }
 
 static void print_usage(const char *argv0)

--- a/src/increment.inc
+++ b/src/increment.inc
@@ -1,0 +1,6 @@
+#
+# Integrity Policy Enforcement Test Suite
+# Copyright (C), Microsoft Corporation, All Rights Reserved.
+#
+
++

--- a/test/ipe/templates/__init__.py
+++ b/test/ipe/templates/__init__.py
@@ -112,30 +112,6 @@ class IPETestCase(TestCase):
 
         self.assertEqual(returncode, PERMISSION_ERROR_CODE)
 
-    def test_smoke_interpreter_command_mode_allow(self):
-        from ipe.templates.smoke.simple import interpreter_command_mode
-
-        if SIMPLE_TEST_KEY not in self.__tests:
-            self.skipTest("Simple tests not selected...")
-
-        interpreter_path = f"{self._allow}/bin/inc"
-
-        (returncode, _, stderr) = interpreter_command_mode(interpreter_path, "+")
-        if stderr != b'':
-            logging.error(f"smoke_interpreter_command_mode_allow with error message: {stderr.decode()}")
-        self.assertEqual(returncode, 0)
-
-    def test_smoke_interpreter_command_mode_deny(self):
-        from ipe.templates.smoke.simple import interpreter_command_mode
-
-        if SIMPLE_TEST_KEY not in self.__tests:
-            self.skipTest("Simple tests not selected...")
-
-        interpreter_path = f"{self._deny}/bin/inc"
-
-        with self.assertRaises(PermissionError):
-            interpreter_command_mode(interpreter_path, "+")
-
     def test_smoke_interpreter_stdin_mode_allow(self):
         from ipe.templates.smoke.simple import interpreter_stdin_mode
 

--- a/test/ipe/templates/__init__.py
+++ b/test/ipe/templates/__init__.py
@@ -112,6 +112,56 @@ class IPETestCase(TestCase):
 
         self.assertEqual(returncode, PERMISSION_ERROR_CODE)
 
+    def test_smoke_interpreter_command_mode_allow(self):
+        from ipe.templates.smoke.simple import interpreter_command_mode
+
+        if SIMPLE_TEST_KEY not in self.__tests:
+            self.skipTest("Simple tests not selected...")
+
+        interpreter_path = f"{self._allow}/bin/inc"
+
+        (returncode, _, stderr) = interpreter_command_mode(interpreter_path, "+")
+        if stderr != b'':
+            logging.error(f"smoke_interpreter_command_mode_allow with error message: {stderr.decode()}")
+        self.assertEqual(returncode, 0)
+
+    def test_smoke_interpreter_command_mode_deny(self):
+        from ipe.templates.smoke.simple import interpreter_command_mode
+
+        if SIMPLE_TEST_KEY not in self.__tests:
+            self.skipTest("Simple tests not selected...")
+
+        interpreter_path = f"{self._deny}/bin/inc"
+
+        with self.assertRaises(PermissionError):
+            interpreter_command_mode(interpreter_path, "+")
+
+    def test_smoke_interpreter_stdin_mode_allow(self):
+        from ipe.templates.smoke.simple import interpreter_stdin_mode
+
+        if SIMPLE_TEST_KEY not in self.__tests:
+            self.skipTest("Simple tests not selected...")
+
+        interpreter_path = f"{self._allow}/bin/inc"
+        script_path = f"{self._allow}/script/increment.inc"
+
+        (returncode, _, stderr) = interpreter_stdin_mode(interpreter_path, script_path)
+        if stderr != b'':
+            logging.error(f"smoke_interpreter_stdin_mode_allow with error message: {stderr.decode()}")
+        self.assertEqual(returncode, 0)
+
+    def test_smoke_interpreter_stdin_mode_deny(self):
+        from ipe.templates.smoke.simple import interpreter_stdin_mode
+
+        if SIMPLE_TEST_KEY not in self.__tests:
+            self.skipTest("Simple tests not selected...")
+
+        interpreter_path = f"{self._allow}/bin/inc"
+        script_path = f"{self._deny}/script/increment.inc"
+
+        (returncode, _, _) = interpreter_stdin_mode(interpreter_path, script_path)
+        self.assertEqual(returncode, PERMISSION_ERROR_CODE)
+
     def test_smoke_memfd_deny(self):
         from ipe.templates.smoke.simple import exec_memfd
 

--- a/test/ipe/templates/__init__.py
+++ b/test/ipe/templates/__init__.py
@@ -84,6 +84,34 @@ class IPETestCase(TestCase):
         with self.assertRaises(PermissionError):
             interpreter(self._deny)
 
+    def test_smoke_indirect_script_allow(self):
+        from ipe.templates.smoke.simple import indirect_script
+
+        if SIMPLE_TEST_KEY not in self.__tests:
+            self.skipTest("Simple tests not selected...")
+
+        inc_cmd = f"{self._allow}/bin/inc"
+        inc_args = f"{self._allow}/script/increment.inc"
+
+        (returncode, _, stderr) = indirect_script(inc_cmd, inc_args)
+
+        if stderr != b'':
+            logging.error(f"test_smoke_indirect_script_allow with error messge: {stderr.decode()}")
+        self.assertEqual(returncode, 0)
+
+    def test_smoke_indirect_script_deny(self):
+        from ipe.templates.smoke.simple import indirect_script
+
+        if SIMPLE_TEST_KEY not in self.__tests:
+            self.skipTest("Simple tests not selected...")
+
+        inc_cmd = f"{self._allow}/bin/inc"
+        inc_args = f"{self._deny}/script/increment.inc"
+
+        (returncode, _, _) = indirect_script(inc_cmd, inc_args)
+
+        self.assertEqual(returncode, PERMISSION_ERROR_CODE)
+
     def test_smoke_memfd_deny(self):
         from ipe.templates.smoke.simple import exec_memfd
 

--- a/test/ipe/templates/smoke/simple.py
+++ b/test/ipe/templates/smoke/simple.py
@@ -82,21 +82,6 @@ def indirect_script(interpreter_path, script_path):
     """
     return util._exec(interpreter_path, [script_path])
 
-def interpreter_command_mode(interpreter_path, command):
-    """
-        interpreter_command_mode:
-          Test interpreter command-line execution mode (-c option).
-
-        Uses an interpreter's -c option to execute a command directly.
-        This tests that command-line execution uses AT_EXECVE_CHECK
-        for consistent IPE enforcement across all execution modes.
-
-        @interpreter_path: path to the interpreter binary
-        @command: command string to execute
-        @rv: (return code, stdout, stderr)
-    """
-    return util._exec(interpreter_path, ["-c", command])
-
 def interpreter_stdin_mode(interpreter_path, script_path):
     """
         interpreter_stdin_mode:
@@ -110,8 +95,8 @@ def interpreter_stdin_mode(interpreter_path, script_path):
         @script_path: path to the script to pipe as stdin
         @rv: (return code, stdout, stderr)
     """
-    import subprocess
-    with open(script_path, 'rb') as script_file:
-        result = subprocess.run([interpreter_path, "-i"],
-                              stdin=script_file, capture_output=True, timeout=5)
-        return (result.returncode, result.stdout, result.stderr)
+    # Get shell from same volume
+    shell_path = interpreter_path.rsplit("/", 1)[0] + "/sh"
+
+    cmd = f"{interpreter_path} -i < {script_path}"
+    return util._exec(shell_path, ["-c", cmd])

--- a/test/ipe/templates/smoke/simple.py
+++ b/test/ipe/templates/smoke/simple.py
@@ -70,7 +70,7 @@ def ffi(path, securityfs_root):
 def indirect_script(interpreter_path, script_path):
     """
         indirect_script:
-          Test script enforcement via interpreter
+          Test script enforcement via interpreter.
 
         Uses an interpreter (like inc) to execute a script file.
         This tests IPE's ability to enforce policies on indirectly
@@ -81,3 +81,37 @@ def indirect_script(interpreter_path, script_path):
         @rv: (return code, stdout, stderr)
     """
     return util._exec(interpreter_path, [script_path])
+
+def interpreter_command_mode(interpreter_path, command):
+    """
+        interpreter_command_mode:
+          Test interpreter command-line execution mode (-c option).
+
+        Uses an interpreter's -c option to execute a command directly.
+        This tests that command-line execution uses AT_EXECVE_CHECK
+        for consistent IPE enforcement across all execution modes.
+
+        @interpreter_path: path to the interpreter binary
+        @command: command string to execute
+        @rv: (return code, stdout, stderr)
+    """
+    return util._exec(interpreter_path, ["-c", command])
+
+def interpreter_stdin_mode(interpreter_path, script_path):
+    """
+        interpreter_stdin_mode:
+          Test interpreter stdin execution mode (-i option).
+
+        Uses an interpreter's -i option to execute a script via stdin.
+        This tests that stdin execution uses AT_EXECVE_CHECK
+        for consistent IPE enforcement across all execution modes.
+
+        @interpreter_path: path to the interpreter binary
+        @script_path: path to the script to pipe as stdin
+        @rv: (return code, stdout, stderr)
+    """
+    import subprocess
+    with open(script_path, 'rb') as script_file:
+        result = subprocess.run([interpreter_path, "-i"],
+                              stdin=script_file, capture_output=True, timeout=5)
+        return (result.returncode, result.stdout, result.stderr)

--- a/test/ipe/templates/smoke/simple.py
+++ b/test/ipe/templates/smoke/simple.py
@@ -66,3 +66,18 @@ def ffi(path, securityfs_root):
     import ctypes
     util.ipe_enforce_mode_on(securityfs_root)
     ctypes.CFUNCTYPE(None, ctypes.c_int)(lambda x: None)
+
+def indirect_script(interpreter_path, script_path):
+    """
+        indirect_script:
+          Test script enforcement via interpreter
+
+        Uses an interpreter (like inc) to execute a script file.
+        This tests IPE's ability to enforce policies on indirectly
+        executed scripts through interpreters.
+
+        @interpreter_path: path to the interpreter binary
+        @script_path: path to the script to execute
+        @rv: (return code, stdout, stderr)
+    """
+    return util._exec(interpreter_path, [script_path])


### PR DESCRIPTION
This PR adds tests for AT_EXECVE_CHECK flag to enable IPE policy enforcement on interpreted scripts. 

**Changes**
- **src/inc.c**: New interpreter program that uses AT_EXECVE_CHECK to consult IPE before executing scripts
- **src/increment.inc**: Test script for validating the interpreter functionality  
- **Makefile**: Updated build configuration for kernel header compilation (Linux 6.14+)
- **test/**: Updated test templates to support new script interpretation features